### PR TITLE
fix: 外部キー設定で自動で付与されるバリデーションの記載を削除 #36

### DIFF
--- a/app/models/mutter.rb
+++ b/app/models/mutter.rb
@@ -3,6 +3,5 @@ class Mutter < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :like_users, through: :likes, source: :user
   default_scope { order(created_at: :desc) }
-  validates :user_id, presence: true
   validates :content, presence: true, length: { maximum: 140 }
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,6 +1,4 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: "User"
   belongs_to :followed, class_name: "User"
-  validates :follower_id, presence: true
-  validates :followed_id, presence: true
 end


### PR DESCRIPTION
## 変更点
- 外部キーを設定した際に自動で付与されるバリーデーションを記載していた為削除